### PR TITLE
Use fog-brightbox gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 0.2.1 (unreleased)
 
 * Confirm before destroying server
-* Handle BoxURL before validate on box startup.
+* HandleBox before validate on box startup.
+* Use fog-brightbox module to reduce dependencies.
 
 # 0.2.0 (April 19, 2013)
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ group :development do
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
 end
+
+group :plugins do
+  gem "vagrant-brightbox", :path => "."
+end

--- a/lib/vagrant-brightbox/action.rb
+++ b/lib/vagrant-brightbox/action.rb
@@ -128,7 +128,7 @@ module VagrantPlugins
 
       def self.action_up
         Vagrant::Action::Builder.new.tap do |b|
-          b.use HandleBoxUrl
+          b.use HandleBox
           b.use ConfigValidate
           b.use ConnectBrightbox
           b.use Call, IsCreated do |env, b2|

--- a/lib/vagrant-brightbox/action.rb
+++ b/lib/vagrant-brightbox/action.rb
@@ -11,56 +11,56 @@ module VagrantPlugins
       # This action is called to destroy the remote machine.
       def self.action_destroy
         Vagrant::Action::Builder.new.tap do |b|
-	  b.use Call, DestroyConfirm do |env, b2|
-	    if env[:result]
-	      b2.use ConfigValidate
-	      b2.use Call, IsCreated do |env2, b3|
-		if env2[:result]
-		  b3.use ConnectBrightbox
-		  b3.use DeleteServer
-		else
-		  b3.use MessageNotCreated
-		end
-	      end
-	    else
-	      b2.use MessageWillNotDestroy
-	    end
-	  end
+          b.use Call, DestroyConfirm do |env, b2|
+            if env[:result]
+              b2.use ConfigValidate
+              b2.use Call, IsCreated do |env2, b3|
+                if env2[:result]
+                  b3.use ConnectBrightbox
+                  b3.use DeleteServer
+                else
+                  b3.use MessageNotCreated
+                end
+              end
+            else
+              b2.use MessageWillNotDestroy
+            end
+          end
         end
       end
 
       # This action is called to halt the server - gracefully or by force.
       def self.action_halt
         Vagrant::Action::Builder.new.tap do |b|
-	  b.use ConfigValidate
-	  b.use Call, IsCreated do |env, b2|
-	    if env[:result]
-	      b2.use Call, GracefulHalt, :inactive, :active do |env2, b3|
-	        if !env2[:result]
-		  b3.use ConnectBrightbox
-		  b3.use ForcedHalt
-		end
-	      end
-	    else
-	      b2.use MessageNotCreated
-	    end
-	  end
-	end
+          b.use ConfigValidate
+          b.use Call, IsCreated do |env, b2|
+            if env[:result]
+              b2.use Call, GracefulHalt, :inactive, :active do |env2, b3|
+                if !env2[:result]
+                  b3.use ConnectBrightbox
+                  b3.use ForcedHalt
+                end
+              end
+            else
+              b2.use MessageNotCreated
+            end
+          end
+        end
       end
 
       # This action reloads the machine - essentially shutting it down
       # and bringing it back up again in the new configuration.
       def self.action_reload
         Vagrant::Action::Builder.new.tap do |b|
-	  b.use Call, IsCreated do |env, b2|
-	    if env[:result]
-	      b2.use action_halt
-	      b2.use action_up
-	    else
-	      b2.use MessageNotCreated
-	    end
-	  end
-	end
+          b.use Call, IsCreated do |env, b2|
+            if env[:result]
+              b2.use action_halt
+              b2.use action_up
+            else
+              b2.use MessageNotCreated
+            end
+          end
+        end
       end
 
       # This action is called when `vagrant provision` is called.
@@ -69,15 +69,14 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use Call, IsCreated do |env, b2|
             if env[:result]
-	      b2.use Provision
-	      b2.use SyncFolders
-	    else
+              b2.use Provision
+              b2.use SyncFolders
+            else
               b2.use MessageNotCreated
             end
           end
         end
       end
-      
 
       # This action is called to read the SSH info of the machine. The
       # resulting state is expected to be put into the `:machine_ssh_info`
@@ -106,8 +105,8 @@ module VagrantPlugins
           b.use ConfigValidate
           b.use Call, IsCreated do |env, b2|
             if env[:result]
-	      b2.use SSHExec
-	    else
+              b2.use SSHExec
+            else
               b2.use MessageNotCreated
             end
           end
@@ -116,37 +115,37 @@ module VagrantPlugins
 
       def self.action_ssh_run
         Vagrant::Action::Builder.new.tap do |b|
-	  b.use ConfigValidate
-	  b.use Call, IsCreated do |env, b2|
-	    if env[:result]
-	      b2.use SSHRun
-	    else
-	      b2.use MessageNotCreated
-	    end
-	  end
-	end
+          b.use ConfigValidate
+          b.use Call, IsCreated do |env, b2|
+            if env[:result]
+              b2.use SSHRun
+            else
+              b2.use MessageNotCreated
+            end
+          end
+        end
       end
 
       def self.action_up
         Vagrant::Action::Builder.new.tap do |b|
-	  b.use HandleBoxUrl
+          b.use HandleBoxUrl
           b.use ConfigValidate
-	  b.use ConnectBrightbox
+          b.use ConnectBrightbox
           b.use Call, IsCreated do |env, b2|
             if env[:result]
-	      b2.use Call, IsRunning do |env2, b3|
-	        if env2[:result]
-		  b3.use MessageAlreadyCreated
-		else
-		  b3.use StartServer
-		  b3.use MapCloudIp
-		end
-	      end
-	    else
-	      b2.use TimedProvision
-	      b2.use SyncFolders
-	      b2.use CreateServer
-	      b2.use MapCloudIp
+              b2.use Call, IsRunning do |env2, b3|
+                if env2[:result]
+                  b3.use MessageAlreadyCreated
+                else
+                  b3.use StartServer
+                  b3.use MapCloudIp
+                end
+              end
+            else
+              b2.use TimedProvision
+              b2.use SyncFolders
+              b2.use CreateServer
+              b2.use MapCloudIp
             end
           end
         end
@@ -154,15 +153,15 @@ module VagrantPlugins
 
       def self.action_package
         Vagrant::Action::Builder.new.tap do |b|
-	  b.use Unsupported
-	end
+          b.use Unsupported
+        end
       end
 
       class << self
-	alias action_resume action_package
-	alias action_suspend action_package
+        alias action_resume action_package
+        alias action_suspend action_package
       end
-        
+
       # The autoload farm
       action_root = Pathname.new(File.expand_path("../action", __FILE__))
       autoload :ConnectBrightbox, action_root.join("connect_brightbox")

--- a/lib/vagrant-brightbox/action/connect_brightbox.rb
+++ b/lib/vagrant-brightbox/action/connect_brightbox.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/brightbox"
 require "log4r"
 
 module VagrantPlugins

--- a/lib/vagrant-brightbox/action/connect_brightbox.rb
+++ b/lib/vagrant-brightbox/action/connect_brightbox.rb
@@ -20,32 +20,32 @@ module VagrantPlugins
           # Get the configs
           region_config     = env[:machine].provider_config.get_region_config(region)
           client_id     = region_config.client_id
-	  client_secret = region_config.secret
-	  username      = region_config.username
-	  password      = region_config.password
-	  account       = region_config.account
-	  auth_url      = region_config.auth_url
-	  api_url       = region_config.api_url
+          client_secret = region_config.secret
+          username      = region_config.username
+          password      = region_config.password
+          account       = region_config.account
+          auth_url      = region_config.auth_url
+          api_url       = region_config.api_url
 
           @logger.info("Connecting to Brightbox...")
-	  @logger.info("Fog credentials are: #{Fog.credentials.inspect}")
-	  fog_options={
+          @logger.info("Fog credentials are: #{Fog.credentials.inspect}")
+          fog_options = {
             :provider => :brightbox,
-	    :brightbox_auth_url => auth_url,
-	    :brightbox_api_url => api_url,
-	    :brightbox_client_id => client_id,
-	    :brightbox_secret => client_secret,
-	    :brightbox_username => username,
-	    :brightbox_password => password,
-	    :brightbox_account => account,
+            :brightbox_auth_url => auth_url,
+            :brightbox_api_url => api_url,
+            :brightbox_client_id => client_id,
+            :brightbox_secret => client_secret,
+            :brightbox_username => username,
+            :brightbox_password => password,
+            :brightbox_account => account
           }
-	  fog_options.delete_if {|k, v| v.nil? }
-	  @logger.info("Fog compute options are: #{fog_options.inspect}")
+          fog_options.delete_if { |k, v| v.nil? }
+          @logger.info("Fog compute options are: #{fog_options.inspect}")
           env[:brightbox_compute] = Fog::Compute.new(fog_options)
 
           @app.call(env)
-	rescue ArgumentError => e
-	  raise Errors::FogError, :message => e.message
+        rescue ArgumentError => e
+          raise Errors::FogError, :message => e.message
         end
       end
     end

--- a/lib/vagrant-brightbox/action/create_server.rb
+++ b/lib/vagrant-brightbox/action/create_server.rb
@@ -24,45 +24,45 @@ module VagrantPlugins
           region = env[:machine].provider_config.region
 
           # Get the configs
-          region_config      = env[:machine].provider_config.get_region_config(region)
+          region_config    = env[:machine].provider_config.get_region_config(region)
           image_id         = region_config.image_id
           zone             = region_config.zone
           server_name      = region_config.server_name
           server_type      = region_config.server_type
           server_groups    = region_config.server_groups
-	  user_data	   = region_config.user_data
+          user_data        = region_config.user_data
 
-	  zone_id  = normalise_id(
-	    lambda {env[:brightbox_compute].zones},
-	    zone,
-	    /^zon-/)
-	  server_type_id = normalise_id(
-	    lambda {env[:brightbox_compute].flavors},
-	    server_type,
-	    /^typ-/)
+          zone_id  = normalise_id(
+            lambda { env[:brightbox_compute].zones },
+            zone,
+            /^zon-/)
+          server_type_id = normalise_id(
+            lambda { env[:brightbox_compute].flavors },
+            server_type,
+            /^typ-/)
 
           # Launch!
           env[:ui].info(I18n.t("vagrant_brightbox.launching_server"))
-	  env[:ui].info(I18n.t("vagrant_brightbox.supplied_user_data")) if user_data
+          env[:ui].info(I18n.t("vagrant_brightbox.supplied_user_data")) if user_data
           env[:ui].info(" -- Type: #{server_type}") if server_type
           env[:ui].info(" -- Image: #{image_id}") if image_id
           env[:ui].info(" -- Region: #{region}")
-	  env[:ui].info(" -- Name: #{server_name}") if server_name
+          env[:ui].info(" -- Name: #{server_name}") if server_name
           env[:ui].info(" -- Zone: #{zone}") if zone
           env[:ui].info(" -- Server Groups: #{server_groups.inspect}") if !server_groups.empty?
-	  @logger.info(" -- Zone ID: #{zone_id}") if zone_id
-	  @logger.info(" -- Type ID: #{server_type_id}") if server_type_id
+          @logger.info(" -- Zone ID: #{zone_id}") if zone_id
+          @logger.info(" -- Type ID: #{server_type_id}") if server_type_id
 
           begin
             options = {
-              :image_id           => image_id,
-	      :name		  => server_name,
-              :flavor_id          => server_type_id,
-	      :user_data	  => user_data,
-              :zone_id 		  => zone_id
+              :image_id => image_id,
+              :name => server_name,
+              :flavor_id => server_type_id,
+              :user_data => user_data,
+              :zone_id => zone_id
             }
 
-	    options[:server_groups] = server_groups unless server_groups.empty?
+            options[:server_groups] = server_groups unless server_groups.empty?
 
             server = env[:brightbox_compute].servers.create(options)
           rescue Excon::Errors::HTTPStatusError => e
@@ -74,30 +74,29 @@ module VagrantPlugins
 
           # Wait for the server to build
           env[:metrics]["server_build_time"] = Util::Timer.time do
-	    tries = region_config.server_build_timeout / 2
+            tries = region_config.server_build_timeout / 2
             env[:ui].info(I18n.t("vagrant_brightbox.waiting_for_build"))
-	    begin
-	      retryable(:on => Fog::Errors::TimeoutError, :tries => tries) do
-		# If we're interrupted don't worry about waiting
-		next if env[:interrupted]
+            begin
+              retryable(:on => Fog::Errors::TimeoutError, :tries => tries) do
+                # If we're interrupted don't worry about waiting
+                next if env[:interrupted]
 
-		# Wait for the server to be ready
-		server.wait_for(2) { ready? }
-	      end
-	    rescue Fog::Errors::TimeoutError
-	      # Delete the server
-	      terminate(env)
+                # Wait for the server to be ready
+                server.wait_for(2) { ready? }
+              end
+            rescue Fog::Errors::TimeoutError
+              # Delete the server
+              terminate(env)
 
-	      # Notify the user
-	      raise Errors::ServerBuildTimeout,
-	        timeout: region_config.server_build_timeout
-	    end
+              # Notify the user
+              raise Errors::ServerBuildTimeout, timeout: region_config.server_build_timeout
+            end
           end
 
           @logger.info("Time for server to build: #{env[:metrics]["server_build_time"]}")
 
           if !env[:interrupted]
-	    @app.call(env)
+            @app.call(env)
             env[:metrics]["instance_ssh_time"] = Util::Timer.time do
               # Wait for SSH to be ready.
               env[:ui].info(I18n.t("vagrant_brightbox.waiting_for_ssh"))
@@ -117,25 +116,24 @@ module VagrantPlugins
 
           # Terminate the instance if we were interrupted
           terminate(env) if env[:interrupted]
-
         end
 
-	# Check if machine is ready, trapping only non-fatal errors
-	def ready?(machine)
-	  @logger.info("Checking if SSH is ready or is permanently broken...")
-	  @logger.info("Connecting as '#{machine.ssh_info[:username]}'") if machine.ssh_info[:username]
-	  # Yes this is cheating.
-	  machine.communicate.send(:connect)
-	  @logger.info("SSH is ready")
-	  true
-	# Fatal errors
-	rescue Vagrant::Errors::SSHAuthenticationFailed
-	  raise
-	# Transient errors
-	rescue Vagrant::Errors::VagrantError => e
-	  @logger.info("SSH not up: #{e.inspect}")
-	  return false
-	end
+        # Check if machine is ready, trapping only non-fatal errors
+        def ready?(machine)
+          @logger.info("Checking if SSH is ready or is permanently broken...")
+          @logger.info("Connecting as '#{machine.ssh_info[:username]}'") if machine.ssh_info[:username]
+          # Yes this is cheating.
+          machine.communicate.send(:connect)
+          @logger.info("SSH is ready")
+          true
+          # Fatal errors
+        rescue Vagrant::Errors::SSHAuthenticationFailed
+          raise
+          # Transient errors
+        rescue Vagrant::Errors::VagrantError => e
+          @logger.info("SSH not up: #{e.inspect}")
+          return false
+        end
 
         def recover(env)
           return if env["vagrant.error"].is_a?(Vagrant::Errors::VagrantError)
@@ -154,22 +152,21 @@ module VagrantPlugins
           env[:action_runner].run(Action.action_destroy, destroy_env)
         end
 
-	def normalise_id(collection, element, pattern)
-	  @logger.info("Normalising element #{element.inspect}")
-	  @logger.info("Against pattern #{pattern.inspect}")
-	  case element
-	  when pattern, nil
-	    element
-	  else
-	    result = collection.call.find { |f| f.handle == element }
-	    if result
-	      result.id
-	    else
-	      element
-	    end
-	  end
-	end
-
+        def normalise_id(collection, element, pattern)
+          @logger.info("Normalising element #{element.inspect}")
+          @logger.info("Against pattern #{pattern.inspect}")
+          case element
+          when pattern, nil
+            element
+          else
+            result = collection.call.find { |f| f.handle == element }
+            if result
+              result.id
+            else
+              element
+            end
+          end
+        end
       end
     end
   end

--- a/lib/vagrant-brightbox/action/forced_halt.rb
+++ b/lib/vagrant-brightbox/action/forced_halt.rb
@@ -13,11 +13,11 @@ module VagrantPlugins
         def call(env)
           server = env[:brightbox_compute].servers.get(env[:machine].id)
 
-	  if server.ready?
-	    # Stop the server.
-	    env[:ui].info(I18n.t("vagrant_brightbox.stopping_server"))
-	    server.stop
-	  end
+          if server.ready?
+            # Stop the server.
+            env[:ui].info(I18n.t("vagrant_brightbox.stopping_server"))
+            server.stop
+          end
 
           @app.call(env)
         end

--- a/lib/vagrant-brightbox/action/map_cloud_ip.rb
+++ b/lib/vagrant-brightbox/action/map_cloud_ip.rb
@@ -4,64 +4,61 @@ module VagrantPlugins
   module Brightbox
     module Action
       class MapCloudIp
-
         def initialize(app, env)
           @app = app
           @logger = Log4r::Logger.new("vagrant_brightbox::action::map_cloud_ips")
         end
 
         def call(env)
-
           @app.call(env)
 
-	  machine = env[:machine]
+          machine = env[:machine]
 
-	  if no_cloud_ips_required?(env[:machine].config.vm.networks)
-	    @logger.info("No public ipv4 network required")
-	    return
-	  end
+          if no_cloud_ips_required?(env[:machine].config.vm.networks)
+            @logger.info("No public ipv4 network required")
+            return
+          end
 
-	  if machine.id.nil?
-	    @logger.info("No server found - can't map public ips")
-	    return
-	  end
+          if machine.id.nil?
+            @logger.info("No server found - can't map public ips")
+            return
+          end
 
-	  server = env[:brightbox_compute].servers.get(machine.id)
-	  if server.nil?
-	    @logger.info("Machine cannot be found; assuming it got destroyed.")
-	    machine.id = nil
-	    return
-	  end
+          server = env[:brightbox_compute].servers.get(machine.id)
+          if server.nil?
+            @logger.info("Machine cannot be found; assuming it got destroyed.")
+            machine.id = nil
+            return
+          end
 
-	  unless server.cloud_ips.empty?
-	    @logger.info("Server already has public ip address.")
-	    return
-	  end
+          unless server.cloud_ips.empty?
+            @logger.info("Server already has public ip address.")
+            return
+          end
 
-	  target_ip = unallocated_cloud_ip(env[:brightbox_compute].cloud_ips)
+          target_ip = unallocated_cloud_ip(env[:brightbox_compute].cloud_ips)
 
-	  if target_ip.nil?
-	    @logger.info("Couldn't allocate a cloud ip")
-	    env[:ui].info I18n.t("vagrant_brightbox.errors.no_free_cloud_ip")
-	    return
-	  end
+          if target_ip.nil?
+            @logger.info("Couldn't allocate a cloud ip")
+            env[:ui].info I18n.t("vagrant_brightbox.errors.no_free_cloud_ip")
+            return
+          end
 
-	  target_ip.map(server)
-	  env[:ui].info I18n.t("vagrant_brightbox.mapped_cloud_ip", :server => server.id, :cloud_ip => target_ip.public_ip)
+          target_ip.map(server)
+          env[:ui].info I18n.t("vagrant_brightbox.mapped_cloud_ip", :server => server.id, :cloud_ip => target_ip.public_ip)
 
         end
 
-	def unallocated_cloud_ip(ip_list)
-	  ip_list.all.detect(ip_list.method(:allocate)) {|ip| !ip.mapped? }
-	end
+        def unallocated_cloud_ip(ip_list)
+          ip_list.all.detect(ip_list.method(:allocate)) { |ip| !ip.mapped? }
+        end
 
-	def no_cloud_ips_required?(networks)
-	  networks.any? do |x|
-	    x.first == :private_network ||
-	      (x.first == :public_network && element[1][:ipv6])
-	  end
-	end
-
+        def no_cloud_ips_required?(networks)
+          networks.any? do |x|
+            x.first == :private_network ||
+              (x.first == :public_network && element[1][:ipv6])
+          end
+        end
       end
     end
   end

--- a/lib/vagrant-brightbox/action/read_ssh_info.rb
+++ b/lib/vagrant-brightbox/action/read_ssh_info.rb
@@ -29,16 +29,16 @@ module VagrantPlugins
             return nil
           end
 
-	  if use_private_network?(machine.config.vm.networks)
-	    host_name = server.fqdn
-	  elsif use_ipv6_public_network?(machine.config.vm.networks)
-	    host_name = "ipv6.#{server.fqdn}"
-	  elsif server.public_ip_address
-	    host_name = server.dns_name
-	  else
-	    @logger.error("Cannot find public ip address - defaulting to private")
-	    host_name = server.fqdn
-	  end
+          if use_private_network?(machine.config.vm.networks)
+            host_name = server.fqdn
+          elsif use_ipv6_public_network?(machine.config.vm.networks)
+            host_name = "ipv6.#{server.fqdn}"
+          elsif server.public_ip_address
+            host_name = server.dns_name
+          else
+            @logger.error("Cannot find public ip address - defaulting to private")
+            host_name = server.fqdn
+          end
 
           # Read the DNS info
           return {
@@ -47,16 +47,15 @@ module VagrantPlugins
           }
         end
 
-	def use_private_network?(network_structure)
-	  network_structure.any? {|x| x.first == :private_network }
-	end
+        def use_private_network?(network_structure)
+          network_structure.any? { |x| x.first == :private_network }
+        end
 
-	def use_ipv6_public_network?(network_structure)
-	  network_structure.any? do |element|
-	    element.first == :public_network && element[1][:ipv6]
-	  end
-	end
-
+        def use_ipv6_public_network?(network_structure)
+          network_structure.any? do |element|
+            element.first == :public_network && element[1][:ipv6]
+          end
+        end
       end
     end
   end

--- a/lib/vagrant-brightbox/action/start_server.rb
+++ b/lib/vagrant-brightbox/action/start_server.rb
@@ -13,12 +13,12 @@ module VagrantPlugins
         def call(env)
           server = env[:brightbox_compute].servers.get(env[:machine].id)
 
-	  # Make the action idempotent
-	  unless server.ready?
-	    # start the server.
-	    env[:ui].info(I18n.t("vagrant_brightbox.starting_server"))
-	    server.start
-	  end
+          # Make the action idempotent
+          unless server.ready?
+            # start the server.
+            env[:ui].info(I18n.t("vagrant_brightbox.starting_server"))
+            server.start
+          end
 
           @app.call(env)
         end

--- a/lib/vagrant-brightbox/action/sync_folders.rb
+++ b/lib/vagrant-brightbox/action/sync_folders.rb
@@ -7,7 +7,7 @@ require "vagrant/util/scoped_hash_override"
 module VagrantPlugins
   module Brightbox
     module Action
-      # This middleware uses `rsync` to sync the folders 
+      # This middleware uses `rsync` to sync the folders
       class SyncFolders
         include Vagrant::Util::ScopedHashOverride
 
@@ -35,8 +35,8 @@ module VagrantPlugins
             hostpath = "#{hostpath}/" if hostpath !~ /\/$/
 
             env[:ui].info(I18n.t("vagrant_brightbox.rsync_folder",
-                                :hostpath => hostpath,
-                                :guestpath => guestpath))
+                                 :hostpath => hostpath,
+                                 :guestpath => guestpath))
 
             # Create the guest path
             env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")

--- a/lib/vagrant-brightbox/action/unsupported.rb
+++ b/lib/vagrant-brightbox/action/unsupported.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         end
 
         def call(env)
-	  env[:ui].warn(I18n.t("vagrant_brightbox.unsupported"))
+          env[:ui].warn(I18n.t("vagrant_brightbox.unsupported"))
 
           @app.call(env)
         end
@@ -15,4 +15,3 @@ module VagrantPlugins
     end
   end
 end
-

--- a/lib/vagrant-brightbox/config.rb
+++ b/lib/vagrant-brightbox/config.rb
@@ -34,10 +34,9 @@ module VagrantPlugins
       attr_accessor :password
 
       # The account id of the account on which operations should be performed
-      # 
+      #
       # @return [String]
       attr_accessor :account
-
 
       # The ID of the Image to use.
       #
@@ -81,7 +80,7 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :user_data
 
-      def initialize(region_specific=false)
+      def initialize(region_specific = false)
         @client_id      = UNSET_VALUE
         @secret  = UNSET_VALUE
         @api_url  = UNSET_VALUE
@@ -91,12 +90,12 @@ module VagrantPlugins
         @account  = UNSET_VALUE
         @image_id                = UNSET_VALUE
         @zone  = UNSET_VALUE
-	@server_build_timeout = UNSET_VALUE
+        @server_build_timeout = UNSET_VALUE
         @server_type      = UNSET_VALUE
-	@server_name	  = UNSET_VALUE
+        @server_name	  = UNSET_VALUE
         @region             = UNSET_VALUE
         @server_groups    = UNSET_VALUE
-	@user_data	    = UNSET_VALUE
+        @user_data	    = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -118,7 +117,7 @@ module VagrantPlugins
       # @param [Hash] attributes Direct attributes to set on the configuration
       #   as a shortcut instead of specifying a full block.
       # @yield [config] Yields a new Brightbox configuration.
-      def region_config(region, attributes=nil, &block)
+      def region_config(region, attributes = nil, &block)
         # Append the block to the list of region configs for that region.
         # We'll evaluate these upon finalization.
         @__region_config[region] ||= []
@@ -182,11 +181,11 @@ module VagrantPlugins
         @server_name = nil if @server_name == UNSET_VALUE
         @zone = nil if @zone == UNSET_VALUE
 
-	# User data is nil by default
-	@user_data = nil if @user_data == UNSET_VALUE
+        # User data is nil by default
+        @user_data = nil if @user_data == UNSET_VALUE
 
-	# The default timeout is 120 seconds
-	@server_build_timeout = 120 if @server_build_timeout == UNSET_VALUE
+        # The default timeout is 120 seconds
+        @server_build_timeout = 120 if @server_build_timeout == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.
@@ -218,20 +217,20 @@ module VagrantPlugins
 
         errors << I18n.t("vagrant_brightbox.config.region_required") if @region.nil?
 
-	errors << I18n.t("vagrant_brightbox.config.region_invalid") unless valid_region?
+        errors << I18n.t("vagrant_brightbox.config.region_invalid") unless valid_region?
 
         if @region && valid_region?
           # Get the configuration for the region we're using and validate only
           # that region.
           config = get_region_config(@region)
 
-	  # Secret could be in fog config file. 
-	  unless fog_config_file_exists?
-	    errors << I18n.t("vagrant_brightbox.config.client_id_required") if \
-	      config.client_id.nil?
-	    errors << I18n.t("vagrant_brightbox.config.secret_required") if \
-	      config.secret.nil?
-	  end
+          # Secret could be in fog config file.
+          unless fog_config_file_exists?
+            errors << I18n.t("vagrant_brightbox.config.client_id_required") if \
+              config.client_id.nil?
+            errors << I18n.t("vagrant_brightbox.config.secret_required") if \
+              config.secret.nil?
+          end
 
         end
 
@@ -244,7 +243,7 @@ module VagrantPlugins
 
       def valid_region?
         return false unless @region =~ /gb1/
-	@region == 'gb1' || !(@auth_url.nil? || @api_url.nil?)
+        @region == 'gb1' || !(@auth_url.nil? || @api_url.nil?)
       end
 
       # This gets the configuration for a specific region. It shouldn't

--- a/lib/vagrant-brightbox/errors.rb
+++ b/lib/vagrant-brightbox/errors.rb
@@ -9,20 +9,20 @@ module VagrantPlugins
 
       class FogError < VagrantBrightboxError
         def initialize(message = nil, *args)
-	  if message.is_a?(Hash)
-	    target = message[:message]
-	    if target.respond_to?(:body)
-	      puts target.body.inspect
-	      decode = Fog::JSON.decode(target.body)
-	      if decode["errors"] 
-		message[:message] = decode["error_name"]+":\n"+decode["errors"].join("\n")
-	      elsif decode["error_description"]
-	        message[:message] = decode["error"] + ": " + decode["error_description"]
-	      end
-	    end
-	  end
-	  super
-	end
+          if message.is_a?(Hash)
+            target = message[:message]
+            if target.respond_to?(:body)
+              puts target.body.inspect
+              decode = Fog::JSON.decode(target.body)
+              if decode["errors"]
+                message[:message] = decode["error_name"]+":\n"+decode["errors"].join("\n")
+              elsif decode["error_description"]
+                message[:message] = decode["error"] + ": " + decode["error_description"]
+              end
+            end
+          end
+          super
+        end
         error_key(:fog_error)
       end
 

--- a/vagrant-brightbox.gemspec
+++ b/vagrant-brightbox.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = "Enables Vagrant to manage servers in Brightbox Cloud."
   gem.summary       = "Enables Vagrant to manage servers in Brightbox Cloud."
 
-  gem.add_runtime_dependency "fog", "~> 1.10.0"
+  gem.add_runtime_dependency "fog-brightbox", "~> 0.0.1"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 2.13.0"


### PR DESCRIPTION
This changes the dependencies to rely on the `fog-brightbox` gem which is a module subset of the full `fog` gem. This has lighter dependencies and requires less code on starting.

Also replaces the now deprecated `HandleBoxUrl` action with `HandleBox` following warnings from vagrant 1.5.

Whitespace is also cleaned up.
